### PR TITLE
Fix bytesWr() to be non-destructive to buffer

### DIFF
--- a/usbhost.h
+++ b/usbhost.h
@@ -230,8 +230,11 @@ uint8_t* MAX3421e< SPI_SS, INTR >::bytesWr(uint8_t reg, uint8_t nbytes, uint8_t*
         data_p += nbytes;
 #elif defined(SPI_HAS_TRANSACTION) && !defined(ESP8266) && !defined(ESP32)
         USB_SPI.transfer(reg | 0x02);
-        USB_SPI.transfer(data_p, nbytes);
-        data_p += nbytes;
+        while(nbytes) {
+                USB_SPI.transfer(*data_p);
+                nbytes--;
+                data_p++; // advance data pointer
+        }
 #elif defined(__ARDUINO_X86__)
         USB_SPI.transfer(reg | 0x02);
         USB_SPI.transferBuffer(data_p, NULL, nbytes);


### PR DESCRIPTION
NOT TESTED: will have to watch upstream repo.

From discussion from this Issue:
https://github.com/felis/USB_Host_Shield_2.0/issues/462
https://github.com/felis/USB_Host_Shield_2.0/issues/403
https://github.com/felis/USB_Host_Shield_2.0/issues/410

Arduino SPI API transfer(buffer, size) used in bytesWr() is destructive
and overwrites the buffer to receive data from SPI slave. byteWr() should
keep the buffer untouched there and it is what OutTransfer() expects.

https://github.com/arduino/ArduinoCore-avr/blob/3ba80468d56485f9a078dbd0854b80beaacbcbd4/libraries/SPI/src/SPI.h#L244-L257

The destructive behaviour causes that OutTransfer() resends broken data
in response to NAK from device, because it has to write first byte of
the broken buffer into FIFO again when it gets NAK and resends data,
according to Maxim App Note 4000.

https://github.com/felis/USB_Host_Shield_2.0/blob/5c303ed62c29d8088d1b113870715b9d198d1cb4/Usb.cpp#L375-L376

https://www.maximintegrated.com/en/app-notes/index.mvp/id/4000



BTW, UHS3's bytesWr() is undestructive and it doesn't mess up OutTransfer() when NAK occurs.

https://github.com/felis/UHS30/blob/6f78c4e486be9033b79e8b3eaf1972e8cf5a95cd/libraries/UHS_host/USB_HOST_SHIELD/USB_HOST_SHIELD_INLINE.h#L80-L96