### PR TITLE
Fix TOGGLE error handling

### DIFF
--- a/Usb.cpp
+++ b/Usb.cpp
@@ -172,8 +172,6 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
 
                                 rcode = InTransfer(pep, nak_limit, &read, dataptr);
                                 if(rcode == hrTOGERR) {
-                                        // yes, we flip it wrong here so that next time it is actually correct!
-                                        pep->bmRcvToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 0 : 1;
                                         continue;
                                 }
 
@@ -239,9 +237,6 @@ uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, ui
 #endif
                 rcode = dispatchPkt(tokIN, pep->epAddr, nak_limit); //IN packet to EP-'endpoint'. Function takes care of NAKS.
                 if(rcode == hrTOGERR) {
-                        // yes, we flip it wrong here so that next time it is actually correct!
-                        pep->bmRcvToggle = (regRd(rHRSL) & bmRCVTOGRD) ? 0 : 1;
-                        regWr(rHCTL, (pep->bmRcvToggle) ? bmRCVTOG1 : bmRCVTOG0); //set toggle value
                         continue;
                 }
                 if(rcode) {
@@ -363,9 +358,6 @@ uint8_t USB::OutTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t nbytes, uint8
                                         //return ( rcode);
                                         break;
                                 case hrTOGERR:
-                                        // yes, we flip it wrong here so that next time it is actually correct!
-                                        pep->bmSndToggle = (regRd(rHRSL) & bmSNDTOGRD) ? 0 : 1;
-                                        regWr(rHCTL, (pep->bmSndToggle) ? bmSNDTOG1 : bmSNDTOG0); //set toggle value
                                         break;
                                 default:
                                         goto breakout;


### PR DESCRIPTION
On TOGGLE error you should do nothing on data toggle bit and received data should be ignored.

https://github.com/tmk/USB_Host_Shield_2.0/issues/2
https://github.com/tmk/tmk_keyboard/issues/657
https://github.com/felis/USB_Host_Shield_2.0/pull/438


>If the IN data was error-free but there was a data toggle mismatch (the
DATA0 or DATA1 PID send by the peripheral did not match the endpoint
toggle value), the SIE sends the ACK handshake, but it does not
complement the data toggle or assert the RCVDAVIRQ. The SIE sets HRSL =
0110 (Toggle Error) for this condition. This situation would happen if
the peripheral received a corrupted ACK handshake from the previous IN
transfer. In this case the host ignores the data in the RCVDATA FIFO,
because it represents data that the peripheral mistakenly resent when it
missed the last ACK handshake. By ACK-ing the transfer and not updating
its own toggle bit, the SIE causes the peripheral to complement its
toggle bit, thus forcing the data toggle mechanism back into sync.

MAX3421 Programming Guide p.13